### PR TITLE
Update example YAML to use arrays for plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ steps:
 - label: ":kubernetes: job step"
   branches: master
   plugins:
-    MYOB-Technology/kustomize-job:
-      name: k8s-kustom-job
-      overlay: overlays/environment
+    - MYOB-Technology/kustomize-job:
+        name: k8s-kustom-job
+        overlay: overlays/environment
   agents:
     queue: bk-queue-name
 ```


### PR DESCRIPTION
Hi again @pr8kerl 😊

(This is the same as https://github.com/MYOB-Technology/kustomize-job-buildkite-plugin/pull/2, but I'm not sure which one you'll get to first, so here's all the info again!)

Harriet from Buildkite here 👋🏻 We’ve [updated](https://buildkite.com/changelog/45-updated-syntax-for-using-plugins-in-your-pipeline-yaml) our recommended plugin syntax to use arrays instead of a map, to help ensure plugins are executed in the correct order with all agent versions.

This PR updates your readme example to be the new recommended syntax, and makes them pass the latest [plugin-linter](https://github.com/buildkite-plugins/buildkite-plugin-linter) checks.

Let me know if you have any questions! We’d love to get the readme updated so people use the new best-practice syntax.